### PR TITLE
feat: quicker scans by faster number aggregation

### DIFF
--- a/scan/scan.h
+++ b/scan/scan.h
@@ -31,8 +31,6 @@ typedef struct {
 } ScannerResult;
 
 typedef struct {
-  uint16_t count15;
-  uint16_t count16;
   NumberScores aggregated15;
   NumberScores aggregated16;
   ScanSessionAnalytics session_analytics;


### PR DESCRIPTION
we can get rid of the minimal 3 frames requirement by improving the 15/16 number score aggregation in a simply way:

 - always apply exponential backoff to all aggregates
 - increase just the matching one
 - take the bigger `aggregated.sum()` for decision instead of waiting at least three frames
 - additionally we can remove the 15/16 counters.

I tested it scanning with all my testing cards. It did not increase false positives. But it decreases required scan time noticeable.

Please give it a try.
