### PR TITLE
chore: variable rename and feature disabling

### DIFF
--- a/dmz.cpp
+++ b/dmz.cpp
@@ -495,9 +495,10 @@ void dmz_transform_card(dmz_context *dmz, IplImage *sample, dmz_corner_points co
   llcv_unwarp(dmz, sample, src_points, dst_rect, *transformed);
 }
 
-void dmz_blur_card(IplImage* cardImageRGB, ScannerState* state, int unblur)
+void dmz_blur_card(IplImage* cardImageRGB, ScannerState* state, int unblurDigits)
 {
-    int blurCount = state->mostRecentUsableHSeg.n_offsets - unblur;
+    if (unblurDigits < 0) return;
+    int blurCount = state->mostRecentUsableHSeg.n_offsets - unblurDigits;
     for (int i = 0; i < state->mostRecentUsableHSeg.n_offsets && i < blurCount ; i++) {
         int num_x = state->mostRecentUsableHSeg.offsets[i] - 1;
         int num_y = state->mostRecentUsableVSeg.y_offset - 1;

--- a/dmz.h
+++ b/dmz.h
@@ -93,9 +93,10 @@ bool dmz_detect_edges(IplImage *y_sample, IplImage *cb_sample, IplImage *cr_samp
 // to free transformed.
 void dmz_transform_card(dmz_context *dmz, IplImage *sample, dmz_corner_points corner_points, FrameOrientation orientation, bool upsample, IplImage **transformed);
 
-// Blurs card number digits on a result image
-// the 'unblur' argument defines how many digits not to blur to remain visible.
-void dmz_blur_card(IplImage* cardImageRGB, ScannerState* state, int unblur);
+// Blurs card number digits on a result image.
+// The 'unblurDigits' argument defines how many digits not to blur to remain visible.
+// If 'unblurDigits' is negative, the function will not blur any numbers.
+void dmz_blur_card(IplImage* cardImageRGB, ScannerState* state, int unblurDigits);
 
 // FOR CYTHON USE ONLY
 #if CYTHON_DMZ


### PR DESCRIPTION
After review of the Android changes there is the need for a small addition:

* renaming of unblur to unblurDigits
* if `unblurDigits` is negative the blur is disabled.
