### PR TITLE
Add MasterCard 2-Series

### DIFF
--- a/dmz_olm.cpp
+++ b/dmz_olm.cpp
@@ -58,6 +58,7 @@ dmz_card_info dmz_card_info_for_prefix_and_length(uint8_t *number_array, uint8_t
   
   dmz_card_info card_types[] =
   {
+    {CardTypeMastercard,  16, 4, 2221, 2720},      // MasterCard 2-Series
     {CardTypeDiscover,    14, 3, 300, 305},        // Diners Club (Discover)
     {CardTypeDiscover,    14, 3, 309, 309},        // Diners Club (Discover)
     {CardTypeAmex,        15, 2, 34, 34},          // AmEx


### PR DESCRIPTION
https://www.mctestcards.com/help

`MasterCard is introducing a new series of International Organization for Standardization (ISO) bank identification numbers (BINs) that will begin with 2 (222100-272099), which will be referred to as 2 series BINs.`

… I don't actually possess one of these cards to test. 😬 