### PR TITLE
Forward-declare struct ScannerState for compatibility with the iOS project

### DIFF
--- a/dmz.cpp
+++ b/dmz.cpp
@@ -16,6 +16,7 @@
 #include "cv/warp.h"
 #include "opencv2/core/core_c.h" // needed for IplImage
 #include "opencv2/imgproc/imgproc.hpp"
+#include "scan/scan.h"
 
 #pragma mark life cycle
 

--- a/dmz.h
+++ b/dmz.h
@@ -8,7 +8,6 @@
 //
 
 #include "dmz_olm.h"
-#include "scan/scan.h"
 
 #include "opencv2/core/core_c.h" // needed for IplImage
 
@@ -36,6 +35,9 @@ typedef struct {
   dmz_found_edge bottom;
   dmz_found_edge right;
 } dmz_edges;
+
+typedef struct ScannerState ScannerState;
+
 
 /******* Functions *******/
 

--- a/scan/scan.h
+++ b/scan/scan.h
@@ -30,7 +30,7 @@ typedef struct {
 #endif
 } ScannerResult;
 
-typedef struct {
+typedef struct ScannerState {
   uint16_t count15;
   uint16_t count16;
   NumberScores aggregated15;


### PR DESCRIPTION
Including `scan/scan.h` in `dmz.h` resulted in the iOS library failing to compile because of deeper inclusions that ended up exposing C++ headers.